### PR TITLE
Applying blur effect to visible planets and increasing default planet scale to enhance sense of scale.

### DIFF
--- a/data_stuff/sprite_prototypes.lua
+++ b/data_stuff/sprite_prototypes.lua
@@ -100,10 +100,11 @@ local function create_planet_sprite_prototype(planet)
     if settings.startup["visible-planets-enable-blur"].value == true then
         --Apply blur effect to planet by layering many nearly-transparent copies of sprites shifted slightly from primary sprites.
         --TODO: Add settings to modify blur intensity that aren't difficult to understand.
+        local blurriness = settings.startup["visible-planets-blur-intensity"].value --Relative blurriness
         local blur_count = 8
-        local blur_shift_max = 0.25
-        local blur_shift_start = 0.05
-        local blur_shift_steps= 0.05
+        local blur_shift_max = 0.25 * blurriness
+        local blur_shift_start = 0.05 * blurriness
+        local blur_shift_steps= 0.05 * blurriness
         local brightness_modifier = 1
         local sprites_list = table.deepcopy(sprite_prototype.layers)
         sprite_prototype.layers = {}

--- a/data_stuff/sprite_prototypes.lua
+++ b/data_stuff/sprite_prototypes.lua
@@ -88,13 +88,65 @@ local function create_planet_sprite_prototype(planet)
         local shift_y = planetslib_y
         for _,child in pairs(sprite_prototype.layers) do -- Rotate background bodies about main body.
             child.shift = {shift_x, shift_y}
-            shift_x = (shift_x * math.cos(math.pi/num_children)) - (shift_y * math.sin(math.pi/num_children))
-            shift_y = (shift_x * math.sin(math.pi/num_children)) - (shift_y * math.cos(math.pi/num_children))
+            local shift_x_old = shift_x
+            shift_x = (shift_x_old * math.cos(math.pi/num_children)) - (shift_y * math.sin(math.pi/num_children))
+            shift_y = (shift_x_old * math.sin(math.pi/num_children)) - (shift_y * math.cos(math.pi/num_children))
         end
     end
 
     -- Add main planet as top layer
     table.insert(sprite_prototype.layers, main_layer)
+
+    if settings.startup["visible-planets-enable-blur"].value == true then
+        --Apply blur effect to planet by layering many nearly-transparent copies of sprites shifted slightly from primary sprites.
+        --TODO: Add settings to modify blur intensity that aren't difficult to understand.
+        local blur_count = 8
+        local blur_shift_max = 0.25
+        local blur_shift_start = 0.05
+        local blur_shift_steps= 0.05
+        local brightness_modifier = 1
+        local sprites_list = table.deepcopy(sprite_prototype.layers)
+        sprite_prototype.layers = {}
+        --local shift_x = blur_shift -- Initial shift, top left corner.
+        --local shift_y = blur_shift
+        for _,entry in pairs(sprites_list) do
+            local copy = table.deepcopy(entry)
+            copy.tint = {0,0,0} --black mask to ensure that none of the sprite is transparent where it shouldn't be
+            table.insert(sprite_prototype.layers,copy)
+        end
+        local n = blur_count*(1+(blur_shift_max-blur_shift_start)/blur_shift_steps)
+        for i = 1,blur_count do
+            for blur_shift = blur_shift_start,blur_shift_max,blur_shift_steps do
+                local shift_x = blur_shift * math.cos(i*2*math.pi/blur_count)
+                local shift_y = blur_shift * math.sin(i*2*math.pi/blur_count)
+                for _,child_original in pairs(sprites_list) do -- Rotate background bodies about main body.
+                    local child = table.deepcopy(child_original)
+                    if child.shift then
+                        if not child.shift[1] then
+                            child.shift[1] = shift_x
+                        else
+                            child.shift[1] = child.shift[1] + shift_x
+                        end
+                        if not child.shift[2] then
+                            child.shift[2] = shift_y
+                        else
+                            child.shift[2] = child.shift[2] + shift_y
+                        end
+                    else
+                        child.shift = {shift_x, shift_y}
+                    end
+                        --assert(1/n > 0.01, "".. tostring(1/n))
+                        child.tint = {brightness_modifier/n,brightness_modifier/n,brightness_modifier/n,brightness_modifier/n}
+                        child.blend_mode = "multiplicative-with-alpha"
+                        table.insert(sprite_prototype.layers,child)
+                        
+                    end
+            end
+            
+        end
+    end
+    
+
     data:extend{sprite_prototype}
 end
 

--- a/locale/en/visible-planets-new.cfg
+++ b/locale/en/visible-planets-new.cfg
@@ -23,6 +23,7 @@ visible-planets-planetslib-scale=Background bodies scaling
 visible-planets-planetslib-x=Background render X position
 visible-planets-planetslib-y=Background render Y position
 visible-planets-planetslib-tint=Background render tint
+visible-planets-enable-blur=Enable planet blur
 
 [mod-setting-description]
 visible-planets-regen-renders=Works in game only! Enable this to remove all planet renders, allowing them to be regenerated with new settings. This is only needed to update platforms that can't move; Automated ones will update themselves on departure. (This setting will auto-disable afterwards.)
@@ -43,3 +44,4 @@ visible-planets-planetslib-scale=Scale of bodies rendered by PlanetLib compat, r
 visible-planets-planetslib-x=X position of first background render. Planets with multiple moons will generate additional renders relative to this position.
 visible-planets-planetslib-y=Y position of first background render. Planets with multiple moons will generate additional renders relative to this position.
 visible-planets-planetslib-tint=Lower values will make background renders darker. A value of 1 will render them normally.
+visible-planets-enable-blur=Applies a blurring effect to visible planet sprites. May cause performance issues.

--- a/locale/en/visible-planets-new.cfg
+++ b/locale/en/visible-planets-new.cfg
@@ -24,6 +24,7 @@ visible-planets-planetslib-x=Background render X position
 visible-planets-planetslib-y=Background render Y position
 visible-planets-planetslib-tint=Background render tint
 visible-planets-enable-blur=Enable planet blur
+visible-planets-blur-intensity=Blur intensity
 
 [mod-setting-description]
 visible-planets-regen-renders=Works in game only! Enable this to remove all planet renders, allowing them to be regenerated with new settings. This is only needed to update platforms that can't move; Automated ones will update themselves on departure. (This setting will auto-disable afterwards.)

--- a/settings.lua
+++ b/settings.lua
@@ -19,7 +19,7 @@ data:extend({
         type = "double-setting",
         name = "visible-planets-planet-scale",
         setting_type = "runtime-global",
-        default_value = 6.0,
+        default_value = 18,
         minimum_value = 0.0,
         order = "b[sprite]-b"
     },

--- a/settings.lua
+++ b/settings.lua
@@ -138,13 +138,13 @@ data:extend({
         default_value = 0.5,
         minimum_value = 0,
         maximum_value = 1,
-        order = "b[planetslib]-f"
+        order = "b[planetslib]-e"
     },
     {
         type = "bool-setting",
         name = "visible-planets-enable-blur",
         setting_type = "startup",
-        order = "b[planetslib]-e"
         default_value = false,
+        order = "b[planetslib]-f"
     }
 })

--- a/settings.lua
+++ b/settings.lua
@@ -19,7 +19,7 @@ data:extend({
         type = "double-setting",
         name = "visible-planets-planet-scale",
         setting_type = "runtime-global",
-        default_value = 18,
+        default_value = 6.0,
         minimum_value = 0.0,
         order = "b[sprite]-b"
     },

--- a/settings.lua
+++ b/settings.lua
@@ -144,7 +144,7 @@ data:extend({
         type = "bool-setting",
         name = "visible-planets-enable-blur",
         setting_type = "startup",
-        default_value = true,
         order = "b[planetslib]-e"
+        default_value = false,
     }
 })

--- a/settings.lua
+++ b/settings.lua
@@ -138,6 +138,13 @@ data:extend({
         default_value = 0.5,
         minimum_value = 0,
         maximum_value = 1,
+        order = "b[planetslib]-f"
+    },
+    {
+        type = "bool-setting",
+        name = "visible-planets-enable-blur",
+        setting_type = "startup",
+        default_value = true,
         order = "b[planetslib]-e"
     }
 })

--- a/settings.lua
+++ b/settings.lua
@@ -146,5 +146,12 @@ data:extend({
         setting_type = "startup",
         default_value = false,
         order = "b[planetslib]-f"
+    },
+    {
+        type = "double-setting",
+        name = "visible-planets-blur-intensity",
+        setting_type = "startup",
+        default_value = 1,
+        order = "b[planetslib]-g"
     }
 })


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c4be3d70-9e2e-4649-8f6e-679a9bd6d0cb)
![image](https://github.com/user-attachments/assets/ec17e49d-70fd-4767-9f1b-2192f0a59c7c)
![image](https://github.com/user-attachments/assets/bd1e8295-0f57-447e-bcd5-b076081cdde7)

This PR enhances the sense of scale provided by this mod through two changes.

1. Increased the default planet scale from 6 to 18.
2. Wrote code that applies a blur effect to all planet sprites to create the impression that the player's perspective is focused on their space platform, not on the planet. This covers up pixellation issues that have previously made it untenable to increase the default planet scale without making higher-resolution planet sprites.