### PR TITLE
per planet rotation override with startup settings

### DIFF
--- a/settings.lua
+++ b/settings.lua
@@ -168,5 +168,13 @@ data:extend({
         default_value = 1,
         minimum_value = 0.01,
         order = "c[blur]-b"
+    },
+    { --startup setting for mods to disable planet rotation individually, dont replace value, add planets with separation like "nauvis;arig;test"
+        type = "string-setting",
+        name = "visible-planets-disable-rotation", 
+        setting_type = "startup",
+        default_value = "",
+        allow_blank = true,
+        order = "z"
     }
 })


### PR DESCRIPTION
example usage for other mods through settings-updates.lua

local setting = data.raw["string-setting"]["visible-planets-disable-rotation"] if setting then
    setting.default_value = setting.default_value..(setting.default_value ~= "" and ";" or "").."PLANET_NAME"
end

i would've loved to somehow do this in compat but i didn't want to make "fake" prototypes for data storage, probably a shabby solution but the best i could come up with.